### PR TITLE
validateQuoteMarks: Be less harsh if it simplifies escaping

### DIFF
--- a/presets/wikimedia.json
+++ b/presets/wikimedia.json
@@ -69,7 +69,7 @@
     "requireSpaceAfterLineComment": true,
     "disallowNewlineBeforeBlockStatements": true,
     "validateLineBreaks": "LF",
-    "validateQuoteMarks": "'",
+    "validateQuoteMarks": { "mark": "'", "escape": true },
     "validateIndentation": "\t",
 
     "jsDoc": {


### PR DESCRIPTION
Available in jscs 1.3.0+ but new to me. Seems like a nice way to achieve what we want.
