### PR TITLE
readme: Fix space in mw.org link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Configure JSCS with a `.jscsrc` file using the following contents:
 
 Over time, JSCS implements new rules, alter existing ones, and retire old ones. Changes to the Wikimedia preset should be made as pull requests to this repo, with issues raised [on Phabricator](https://phabricator.wikimedia.org/maniphest/task/create/?projects=javascript).
 
-Major changes should be discussed [on mediawiki.org](https://www.mediawiki.org/wiki/Manual talk:Coding_conventions/JavaScript) or on the [Wikitech mailing list](https://lists.wikimedia.org/mailman/listinfo/wikitech-l) beforehand.
+Major changes should be discussed [on mediawiki.org](https://www.mediawiki.org/wiki/Manual_talk:Coding_conventions/JavaScript) or on the [Wikitech mailing list](https://lists.wikimedia.org/mailman/listinfo/wikitech-l) beforehand.
 
 ## Licence
 


### PR DESCRIPTION
A space in a url actually works in GitHub's parser,
but doesn't in the one npmjs.org uses at:
 https://www.npmjs.com/package/jscs-preset-wikimedia